### PR TITLE
New URI + Fix for QR code

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
   "dependencies": {
     "@babel/polyfill": "^7.0.0",
     "axios": "^0.18.0",
+    "big.js": "^5.2.2",
     "qrcode": "^1.2.0",
     "redom": "^3.12.6",
     "spin.js": "^4.0.0"

--- a/src/utils/dom.js
+++ b/src/utils/dom.js
@@ -1,6 +1,9 @@
 import { el, setStyle, setChildren, mount, unmount } from 'redom'
 import { Spinner } from 'spin.js'
 import QRCode from 'qrcode'
+import Big from './big.mjs';
+
+const multNANO = Big('1000000000000000000000000000000');
 
 class DOM {
   constructor({ onClose }) {
@@ -169,7 +172,9 @@ class DOM {
   showPaymentInfo(data) {
     const { account, amount } = data
 
-    const qrText = `nano:${account}?amount=${amount}`
+    const amount_raw = Big(amount).times(multNANO).toFixed().toString()
+
+    const qrText = `nano:${account}?amount=${amount_raw}`
     const qrCanvas= el('canvas', {
       style: `
         background: white!important;

--- a/src/utils/dom.js
+++ b/src/utils/dom.js
@@ -1,7 +1,7 @@
 import { el, setStyle, setChildren, mount, unmount } from 'redom'
 import { Spinner } from 'spin.js'
 import QRCode from 'qrcode'
-import Big from './big.mjs';
+import Big from 'big.js';
 
 const multNANO = Big('1000000000000000000000000000000');
 

--- a/src/utils/dom.js
+++ b/src/utils/dom.js
@@ -169,7 +169,7 @@ class DOM {
   showPaymentInfo(data) {
     const { account, amount } = data
 
-    const qrText = `xrb:${account}?amount=${amount}`
+    const qrText = `nano:${account}?amount=${amount}`
     const qrCanvas= el('canvas', {
       style: `
         background: white!important;


### PR DESCRIPTION
Changed the URI to the new nano: standard.
The QR code has now the raw value instead of mnano (according to specs).
https://github.com/nanocurrency/nano-node/wiki/URI-and-QR-Code-Standard

Please check if it builds properly, I could not test it on my PC.